### PR TITLE
HLAF-8 better tests

### DIFF
--- a/src/HLAfreq/HLAfreq.py
+++ b/src/HLAfreq/HLAfreq.py
@@ -489,7 +489,7 @@ def combineAF(
             raise AssertionError("The same allele appears multiple times in a dataset")
     if complete:
         if not incomplete_studies(df, datasetID=datasetID).empty:
-            raise AssertionError("AFtab contains studies with AF that doesn't sum to 1. Checkincomplete_studies(AFtab)")
+            raise AssertionError("AFtab contains studies with AF that doesn't sum to 1. Check incomplete_studies(AFtab)")
     if resolution:
         if not check_resolution(df):
             raise AssertionError("AFtab conains alleles at multiple resolutions, check check_resolution(AFtab)")
@@ -549,7 +549,7 @@ def single_loci(AFtab):
         AFtab (pd.DataFrame): Allele frequency data
     """
     if not len(AFtab.loci.unique()) == 1:
-        raise AssertionError("'AFtab' must conatain only 1 loci")
+        raise AssertionError("'AFtab' must contain only 1 loci")
 
 
 def alleles_unique_in_study(AFtab, datasetID="population"):

--- a/src/HLAfreq/HLAfreq.py
+++ b/src/HLAfreq/HLAfreq.py
@@ -8,6 +8,7 @@ estimate HLA frequencies of countries or other regions such as
 global HLA frequencies.
 """
 
+from collections.abc import Iterable
 from bs4 import BeautifulSoup
 import requests
 import pandas as pd
@@ -16,6 +17,33 @@ import matplotlib.pyplot as plt
 import math
 import scipy as sp
 import matplotlib.colors as mcolors
+
+
+def simulate_population(alleles: Iterable[str], locus: str, population: str):
+    pop_size = np.random.randint(len(alleles), 50)
+    samples = np.random.choice(alleles, pop_size, replace=True)
+    counts = pd.Series(samples).value_counts()
+    counts.values / pop_size
+    pop = pd.DataFrame(
+        {
+            "allele": counts.index,
+            "loci": locus,
+            "population": population,
+            "allele_freq": counts.values / pop_size,
+            "sample_size": pop_size,
+        }
+    )
+    return pop
+
+
+def simulate_study(alleles, populations, locus):
+    study = []
+    for i in range(populations):
+        pop = simulate_population(alleles=alleles, locus=locus, population=f"pop_{i}")
+        study.append(pop)
+
+    study = pd.concat(study)
+    return study
 
 
 def makeURL(

--- a/src/HLAfreq/HLAfreq.py
+++ b/src/HLAfreq/HLAfreq.py
@@ -164,7 +164,9 @@ def Npages(bs):
     # Get the table with number of pages
     navtab = bs.find("div", {"id": "divGenNavig"}).find("table", {"class": "table10"})
     if not navtab:
-        raise AssertionError("navtab does not evaluate to True. Check URL returns results in web browser.")
+        raise AssertionError(
+            "navtab does not evaluate to True. Check URL returns results in web browser."
+        )
     # Get cell with ' of ' in
     pagesOfN = [
         td.get_text(strip=True) for td in navtab.find_all("td") if " of " in td.text
@@ -224,7 +226,9 @@ def getAFdata(base_url, timeout=20, format=True, ignoreG=True):
     try:
         bs = BeautifulSoup(requests.get(base_url, timeout=timeout).text, "html.parser")
     except requests.exceptions.ReadTimeout as e:
-        raise Exception("Requests timeout, try a larger `timeout` value for `getAFdata()`") from e
+        raise Exception(
+            "Requests timeout, try a larger `timeout` value for `getAFdata()`"
+        ) from e
     # How many pages of results
     N = Npages(bs)
     print("%s pages of results" % N)
@@ -237,7 +241,9 @@ def getAFdata(base_url, timeout=20, format=True, ignoreG=True):
         try:
             bs = BeautifulSoup(requests.get(url, timeout=timeout).text, "html.parser")
         except requests.exceptions.ReadTimeout as e:
-            raise Exception("Requests timeout, try a larger `timeout` value for `getAFdata()`") from e
+            raise Exception(
+                "Requests timeout, try a larger `timeout` value for `getAFdata()`"
+            ) from e
         tab = parseAF(bs)
         tabs.append(tab)
     print("Download complete")
@@ -367,9 +373,13 @@ def collapse_reduced_alleles(AFtab, datasetID="population"):
     ).reset_index()
     # Within a study each all identical alleles should have the same loci and sample size
     if not all(collapsed["#loci"] == 1):
-        raise AssertionError("Multiple loci found for a single allele in a single population")
+        raise AssertionError(
+            "Multiple loci found for a single allele in a single population"
+        )
     if not all(collapsed["#sample_sizes"] == 1):
-        raise AssertionError("Multiple sample_sizes found for a single allele in a single population")
+        raise AssertionError(
+            "Multiple sample_sizes found for a single allele in a single population"
+        )
     collapsed = collapsed[
         ["allele", "loci", "population", "allele_freq", "sample_size"]
     ]
@@ -401,7 +411,9 @@ def unmeasured_alleles(AFtab, datasetID="population"):
             # What was the sample size for this data?
             dataset_sample_size = datasetAF.sample_size.unique()
             if not (len(dataset_sample_size) == 1):
-                raise AssertionError("dataset_sample_size must be 1, not %s" % len(dataset_sample_size))
+                raise AssertionError(
+                    "dataset_sample_size must be 1, not %s" % len(dataset_sample_size)
+                )
             dataset_sample_size = dataset_sample_size[0]
             # Get all alleles for this locus (across datasets)
             ualleles = df[df.loci == locus].allele.unique()
@@ -489,10 +501,14 @@ def combineAF(
             raise AssertionError("The same allele appears multiple times in a dataset")
     if complete:
         if not incomplete_studies(df, datasetID=datasetID).empty:
-            raise AssertionError("AFtab contains studies with AF that doesn't sum to 1. Check incomplete_studies(AFtab)")
+            raise AssertionError(
+                "AFtab contains studies with AF that doesn't sum to 1. Check incomplete_studies(AFtab)"
+            )
     if resolution:
         if not check_resolution(df):
-            raise AssertionError("AFtab conains alleles at multiple resolutions, check check_resolution(AFtab)")
+            raise AssertionError(
+                "AFtab conains alleles at multiple resolutions, check check_resolution(AFtab)"
+            )
     if format:
         df = formatAF(df, ignoreG)
     if add_unmeasured:
@@ -588,7 +604,9 @@ def id_duplicated_allele(grouped):
     """Reports the allele that has mupltiple sample sizes"""
     duplicated_population = grouped.population.apply(lambda x: any(x.duplicated()))
     if not all(~duplicated_population):
-        raise AssertionError(f"duplicated population within allele {duplicated_population[duplicated_population].index.tolist()}")
+        raise AssertionError(
+            f"duplicated population within allele {duplicated_population[duplicated_population].index.tolist()}"
+        )
 
 
 def population_coverage(p):

--- a/src/HLAfreq/HLAfreq_pymc.py
+++ b/src/HLAfreq/HLAfreq_pymc.py
@@ -29,10 +29,14 @@ def _make_c_array(
             raise AssertionError("The same allele appears multiple times in a dataset")
     if complete:
         if not HLAfreq.incomplete_studies(df, datasetID=datasetID).empty:
-            raise AssertionError("AFtab contains studies with AF that doesn't sum to 1. Check incomplete_studies(AFtab)")
+            raise AssertionError(
+                "AFtab contains studies with AF that doesn't sum to 1. Check incomplete_studies(AFtab)"
+            )
     if resolution:
         if not HLAfreq.check_resolution(df):
-            raise AssertionError("AFtab conains alleles at multiple resolutions, check check_resolution(AFtab)")
+            raise AssertionError(
+                "AFtab conains alleles at multiple resolutions, check check_resolution(AFtab)"
+            )
     if format:
         df = HLAfreq.formatAF(df, ignoreG)
     if add_unmeasured:
@@ -53,8 +57,10 @@ def _make_c_array(
     # The check is that the sum of allele i is the same
     for a, b in zip(np.apply_along_axis(sum, 0, c_array), df.groupby("allele").c.sum()):
         if not math.isclose(a, b):
-            raise AssertionError("Error making c_array sum of single allele"
-                                 "frequency differs between c_array and AFloc")
+            raise AssertionError(
+                "Error making c_array sum of single allele"
+                "frequency differs between c_array and AFloc"
+            )
     return c_array, allele_names
 
 

--- a/src/HLAfreq/examples.py
+++ b/src/HLAfreq/examples.py
@@ -7,4 +7,3 @@ Several detailed `HLAfreq` examples are detailed in `examples/`.
 - [Using priors](https://BarinthusBio.github.io/HLAfreq/HLAfreq/examples/working_with_priors.html)
 - [Credible intervals](https://BarinthusBio.github.io/HLAfreq/HLAfreq/examples/credible_intervals.html)
 """
-

--- a/tests/test_HLAfreq_pymc.py
+++ b/tests/test_HLAfreq_pymc.py
@@ -1,0 +1,68 @@
+import pandas as pd
+import numpy as np
+import pytest
+import HLAfreq
+import HLAfreq.HLAfreq_pymc as HLAhdi
+
+
+@pytest.fixture(
+    params=[
+        ["A*01:01", "A*01:02", "A*01:03"],
+        ["A*01:01:01", "A*01:02:01", "A*01:03:01"],
+        ["A*01:01", "A*01:02", "A*01:03:01"],
+        ["A*01:01", "A*01:02", "A*01:03:01", "A*01:03:02"],
+    ]
+)
+def alleles(request):
+    return request.param
+
+
+@pytest.fixture
+def aftab(alleles):
+    return HLAfreq.simulate_study(alleles, 3, "X")
+
+
+# Not a meaningful test but slow
+# def test_hdi():
+#     hdi = HLAhdi.AFhdi(aftab, credible_interval=0.95)
+#     assert all(hdi.columns == ["lo", "hi", "allele", "post_mean"])
+
+
+def test_correct_c_array(aftab):
+    aftab = HLAfreq.only_complete(aftab)
+    aftab = HLAfreq.decrease_resolution(aftab, 2)
+    aftab['c'] = 2 * aftab.allele_freq * aftab.sample_size
+    c_pivot = aftab.pivot(columns="allele", index="population", values="c")
+    c_array = HLAhdi._make_c_array(aftab)
+    pytest.approx(c_array[0]) == c_pivot
+
+
+def test_correct_c_array_alleles(aftab):
+    aftab = HLAfreq.only_complete(aftab)
+    aftab = HLAfreq.decrease_resolution(aftab, 2)
+    aftab['c'] = 2 * aftab.allele_freq * aftab.sample_size
+    c_pivot = aftab.pivot(columns="allele", index="population", values="c")
+    c_array = HLAhdi._make_c_array(aftab)
+    c_array[1] == c_pivot.columns
+
+
+def test_complete(aftab):
+    aftab = aftab.drop(0)
+    with pytest.raises(AssertionError) as e:
+        HLAhdi._make_c_array(aftab)
+    assert "incomplete_studies" in str(e.value)
+
+
+def test_unique_in_study(aftab):
+    aftab["allele"] = "A*00:00"
+    with pytest.raises(AssertionError) as e:
+        caf = HLAhdi._make_c_array(aftab)
+    assert "same allele appears multiple times" in str(e.value)
+
+
+def test_resolution_check(aftab):
+    aftab.loc[0, "allele"] = aftab.loc[0, "allele"] + ":00:00"
+    with pytest.raises(AssertionError) as e:
+        caf = HLAhdi._make_c_array(aftab)
+    assert "multiple resolutions" in str(e.value)
+

--- a/tests/test_simulated_data.py
+++ b/tests/test_simulated_data.py
@@ -4,75 +4,82 @@ import pandas as pd
 import numpy as np
 from collections.abc import Iterable
 
+
 @pytest.fixture(params=["Thailand"])
 def country(request):
     return request.param
+
 
 @pytest.fixture
 def base_url(country):
     return HLAfreq.makeURL(country)
 
+
 def test_url_string(base_url):
     assert isinstance(base_url, str)
 
-def simulate_population(
-        alleles: Iterable[str],
-        locus: str,
-        population: str
-    ):
+
+def simulate_population(alleles: Iterable[str], locus: str, population: str):
     pop_size = np.random.randint(len(alleles), 50)
     samples = np.random.choice(alleles, pop_size, replace=True)
     counts = pd.Series(samples).value_counts()
-    counts.values/pop_size
-    pop = pd.DataFrame({
-        "allele": counts.index,
-        "loci": locus,
-        "population": population,
-        "allele_freq": counts.values/pop_size,
-        "sample_size": pop_size,
-    })
+    counts.values / pop_size
+    pop = pd.DataFrame(
+        {
+            "allele": counts.index,
+            "loci": locus,
+            "population": population,
+            "allele_freq": counts.values / pop_size,
+            "sample_size": pop_size,
+        }
+    )
     return pop
 
 
 def simulate_study(alleles, populations, locus):
     study = []
     for i in range(populations):
-        pop = simulate_population(
-            alleles = alleles,
-            locus = locus,
-            population = f"pop_{i}"
-        )
+        pop = simulate_population(alleles=alleles, locus=locus, population=f"pop_{i}")
         study.append(pop)
 
     study = pd.concat(study)
     return study
 
-@pytest.fixture(params=[
-    ["A*01:01", "A*01:02", "A*01:03"],
-    ["A*01:01:01", "A*01:02:01", "A*01:03:01"],
-    ["A*01:01", "A*01:02", "A*01:03:01"],
-    ["A*01:01", "A*01:02", "A*01:03:01", "A*01:03:02"],
-])
+
+@pytest.fixture(
+    params=[
+        ["A*01:01", "A*01:02", "A*01:03"],
+        ["A*01:01:01", "A*01:02:01", "A*01:03:01"],
+        ["A*01:01", "A*01:02", "A*01:03:01"],
+        ["A*01:01", "A*01:02", "A*01:03:01", "A*01:03:02"],
+    ]
+)
 def alleles(request):
     return request.param
+
 
 @pytest.fixture
 def aftab(alleles):
     return simulate_study(alleles, 3, "X")
+
 
 @pytest.fixture
 def expected_freq(aftab):
     aftab = HLAfreq.only_complete(aftab)
     aftab = HLAfreq.decrease_resolution(aftab, 2)
     aftab = HLAfreq.unmeasured_alleles(aftab, "population")
-    grouped = aftab.groupby("allele")[['allele_freq','sample_size']]
-    return grouped.apply(lambda x: np.average(x.allele_freq, weights=x.sample_size*2)).values
-    
+    grouped = aftab.groupby("allele")[["allele_freq", "sample_size"]]
+    return grouped.apply(
+        lambda x: np.average(x.allele_freq, weights=x.sample_size * 2)
+    ).values
+
+
 def test_wav(aftab, expected_freq):
     aftab = HLAfreq.only_complete(aftab)
     aftab = HLAfreq.decrease_resolution(aftab, 2)
     caf = HLAfreq.combineAF(aftab)
     assert caf.wav.values == pytest.approx(expected_freq)
+
 
 def test_combineAF(aftab, expected_freq):
     aftab = HLAfreq.only_complete(aftab)
@@ -80,22 +87,26 @@ def test_combineAF(aftab, expected_freq):
     caf = HLAfreq.combineAF(aftab)
     assert caf.allele_freq.values == pytest.approx(expected_freq, rel=5e-2)
 
+
 def test_resolution_check(alleles, aftab):
-    aftab.loc[0,'allele'] = aftab.loc[0,'allele'] + ":00:00"
+    aftab.loc[0, "allele"] = aftab.loc[0, "allele"] + ":00:00"
     with pytest.raises(AssertionError) as e:
         caf = HLAfreq.combineAF(aftab)
     assert "multiple resolutions" in str(e.value)
+
 
 def test_low_res(aftab):
     with pytest.raises(AssertionError) as e:
         HLAfreq.decrease_resolution(aftab, 5)
     assert "resolution below" in str(e.value)
 
+
 def test_single_locus(aftab):
     with pytest.raises(AssertionError) as e:
-        aftab.iloc[0,1] = "Y"
+        aftab.iloc[0, 1] = "Y"
         HLAfreq.combineAF(aftab)
     assert "only 1 loci" in str(e.value)
+
 
 def test_complete(aftab):
     aftab = aftab.drop(0)
@@ -103,16 +114,18 @@ def test_complete(aftab):
         HLAfreq.combineAF(aftab)
     assert "incomplete_studies" in str(e.value)
 
+
 def test_single_sample_size(aftab):
     aftab = HLAfreq.only_complete(aftab)
     aftab = HLAfreq.decrease_resolution(aftab, 2)
-    aftab.loc[0, 'sample_size'] = 51
+    aftab.loc[0, "sample_size"] = 51
     with pytest.raises(AssertionError) as e:
         caf = HLAfreq.combineAF(aftab)
     assert "dataset_sample_size must be 1" in str(e.value)
 
+
 def test_unique_in_study(aftab):
-    aftab['allele'] = "A*00:00"
+    aftab["allele"] = "A*00:00"
     with pytest.raises(AssertionError) as e:
         caf = HLAfreq.combineAF(aftab)
     assert "same allele appears multiple times" in str(e.value)
@@ -120,12 +133,14 @@ def test_unique_in_study(aftab):
 
 def test_multi_loci_allele_decrease_resolution(aftab):
     aftabB = aftab.copy()
-    aftabB.iloc[0,1] = "Y"
+    aftabB.iloc[0, 1] = "Y"
     aftab = pd.concat([aftab, aftabB])
     with pytest.raises(AssertionError) as e:
         HLAfreq.decrease_resolution(aftab, 2)
-    assert "Multiple loci found for a single allele in a single population" in str(e.value)
-    
+    assert "Multiple loci found for a single allele in a single population" in str(
+        e.value
+    )
+
 
 def test_multi_sample_size_allele_decrease_resolution(aftab):
     aftabB = aftab.copy()
@@ -133,5 +148,7 @@ def test_multi_sample_size_allele_decrease_resolution(aftab):
     aftab = pd.concat([aftab, aftabB])
     with pytest.raises(AssertionError) as e:
         HLAfreq.decrease_resolution(aftab, 2)
-    assert "Multiple sample_sizes found for a single allele in a single population" in str(e.value)
-
+    assert (
+        "Multiple sample_sizes found for a single allele in a single population"
+        in str(e.value)
+    )

--- a/tests/test_simulated_data.py
+++ b/tests/test_simulated_data.py
@@ -61,7 +61,7 @@ def test_combineAF(aftab, expected_freq):
     assert caf.allele_freq.values == pytest.approx(expected_freq, rel=5e-2)
 
 
-def test_resolution_check(alleles, aftab):
+def test_resolution_check(aftab):
     aftab.loc[0, "allele"] = aftab.loc[0, "allele"] + ":00:00"
     with pytest.raises(AssertionError) as e:
         caf = HLAfreq.combineAF(aftab)

--- a/tests/test_simulated_data.py
+++ b/tests/test_simulated_data.py
@@ -19,33 +19,6 @@ def test_url_string(base_url):
     assert isinstance(base_url, str)
 
 
-def simulate_population(alleles: Iterable[str], locus: str, population: str):
-    pop_size = np.random.randint(len(alleles), 50)
-    samples = np.random.choice(alleles, pop_size, replace=True)
-    counts = pd.Series(samples).value_counts()
-    counts.values / pop_size
-    pop = pd.DataFrame(
-        {
-            "allele": counts.index,
-            "loci": locus,
-            "population": population,
-            "allele_freq": counts.values / pop_size,
-            "sample_size": pop_size,
-        }
-    )
-    return pop
-
-
-def simulate_study(alleles, populations, locus):
-    study = []
-    for i in range(populations):
-        pop = simulate_population(alleles=alleles, locus=locus, population=f"pop_{i}")
-        study.append(pop)
-
-    study = pd.concat(study)
-    return study
-
-
 @pytest.fixture(
     params=[
         ["A*01:01", "A*01:02", "A*01:03"],
@@ -60,7 +33,7 @@ def alleles(request):
 
 @pytest.fixture
 def aftab(alleles):
-    return simulate_study(alleles, 3, "X")
+    return HLAfreq.simulate_study(alleles, 3, "X")
 
 
 @pytest.fixture

--- a/tests/test_simulated_data.py
+++ b/tests/test_simulated_data.py
@@ -1,0 +1,137 @@
+import pytest
+import HLAfreq
+import pandas as pd
+import numpy as np
+from collections.abc import Iterable
+
+@pytest.fixture(params=["Thailand"])
+def country(request):
+    return request.param
+
+@pytest.fixture
+def base_url(country):
+    return HLAfreq.makeURL(country)
+
+def test_url_string(base_url):
+    assert isinstance(base_url, str)
+
+def simulate_population(
+        alleles: Iterable[str],
+        locus: str,
+        population: str
+    ):
+    pop_size = np.random.randint(len(alleles), 50)
+    samples = np.random.choice(alleles, pop_size, replace=True)
+    counts = pd.Series(samples).value_counts()
+    counts.values/pop_size
+    pop = pd.DataFrame({
+        "allele": counts.index,
+        "loci": locus,
+        "population": population,
+        "allele_freq": counts.values/pop_size,
+        "sample_size": pop_size,
+    })
+    return pop
+
+
+def simulate_study(alleles, populations, locus):
+    study = []
+    for i in range(populations):
+        pop = simulate_population(
+            alleles = alleles,
+            locus = locus,
+            population = f"pop_{i}"
+        )
+        study.append(pop)
+
+    study = pd.concat(study)
+    return study
+
+@pytest.fixture(params=[
+    ["A*01:01", "A*01:02", "A*01:03"],
+    ["A*01:01:01", "A*01:02:01", "A*01:03:01"],
+    ["A*01:01", "A*01:02", "A*01:03:01"],
+    ["A*01:01", "A*01:02", "A*01:03:01", "A*01:03:02"],
+])
+def alleles(request):
+    return request.param
+
+@pytest.fixture
+def aftab(alleles):
+    return simulate_study(alleles, 3, "X")
+
+@pytest.fixture
+def expected_freq(aftab):
+    aftab = HLAfreq.only_complete(aftab)
+    aftab = HLAfreq.decrease_resolution(aftab, 2)
+    aftab = HLAfreq.unmeasured_alleles(aftab, "population")
+    grouped = aftab.groupby("allele")[['allele_freq','sample_size']]
+    return grouped.apply(lambda x: np.average(x.allele_freq, weights=x.sample_size*2)).values
+    
+def test_wav(aftab, expected_freq):
+    aftab = HLAfreq.only_complete(aftab)
+    aftab = HLAfreq.decrease_resolution(aftab, 2)
+    caf = HLAfreq.combineAF(aftab)
+    assert caf.wav.values == pytest.approx(expected_freq)
+
+def test_combineAF(aftab, expected_freq):
+    aftab = HLAfreq.only_complete(aftab)
+    aftab = HLAfreq.decrease_resolution(aftab, 2)
+    caf = HLAfreq.combineAF(aftab)
+    assert caf.allele_freq.values == pytest.approx(expected_freq, rel=5e-2)
+
+def test_resolution_check(alleles, aftab):
+    aftab.loc[0,'allele'] = aftab.loc[0,'allele'] + ":00:00"
+    with pytest.raises(AssertionError) as e:
+        caf = HLAfreq.combineAF(aftab)
+    assert "multiple resolutions" in str(e.value)
+
+def test_low_res(aftab):
+    with pytest.raises(AssertionError) as e:
+        HLAfreq.decrease_resolution(aftab, 5)
+    assert "resolution below" in str(e.value)
+
+def test_single_locus(aftab):
+    with pytest.raises(AssertionError) as e:
+        aftab.iloc[0,1] = "Y"
+        HLAfreq.combineAF(aftab)
+    assert "only 1 loci" in str(e.value)
+
+def test_complete(aftab):
+    aftab = aftab.drop(0)
+    with pytest.raises(AssertionError) as e:
+        HLAfreq.combineAF(aftab)
+    assert "incomplete_studies" in str(e.value)
+
+def test_single_sample_size(aftab):
+    aftab = HLAfreq.only_complete(aftab)
+    aftab = HLAfreq.decrease_resolution(aftab, 2)
+    aftab.loc[0, 'sample_size'] = 51
+    with pytest.raises(AssertionError) as e:
+        caf = HLAfreq.combineAF(aftab)
+    assert "dataset_sample_size must be 1" in str(e.value)
+
+def test_unique_in_study(aftab):
+    aftab['allele'] = "A*00:00"
+    with pytest.raises(AssertionError) as e:
+        caf = HLAfreq.combineAF(aftab)
+    assert "same allele appears multiple times" in str(e.value)
+
+
+def test_multi_loci_allele_decrease_resolution(aftab):
+    aftabB = aftab.copy()
+    aftabB.iloc[0,1] = "Y"
+    aftab = pd.concat([aftab, aftabB])
+    with pytest.raises(AssertionError) as e:
+        HLAfreq.decrease_resolution(aftab, 2)
+    assert "Multiple loci found for a single allele in a single population" in str(e.value)
+    
+
+def test_multi_sample_size_allele_decrease_resolution(aftab):
+    aftabB = aftab.copy()
+    aftabB.loc[0, "sample_size"] = 51
+    aftab = pd.concat([aftab, aftabB])
+    with pytest.raises(AssertionError) as e:
+        HLAfreq.decrease_resolution(aftab, 2)
+    assert "Multiple sample_sizes found for a single allele in a single population" in str(e.value)
+

--- a/tests/test_single_country_caf.py
+++ b/tests/test_single_country_caf.py
@@ -66,8 +66,3 @@ caf = HLAfreq.combineAF(aftab)
 def test_combined_allele_freq():
     assert all(caf.allele_freq == dirichlet([8, 12, 13]).mean())
 
-
-# Not a meaningful test but slow
-# def test_hdi():
-#     hdi = HLAhdi.AFhdi(aftab, credible_interval=0.95)
-#     assert all(hdi.columns == ["lo", "hi", "allele", "post_mean"])

--- a/tests/test_single_country_caf.py
+++ b/tests/test_single_country_caf.py
@@ -3,6 +3,7 @@
 Tests dropping incomplete studies, merging different resolution
 alleles, and combing allele frequency estimates.
 """
+
 import pytest
 import HLAfreq
 from HLAfreq import HLAfreq_pymc as HLAhdi

--- a/tests/test_single_country_caf.py
+++ b/tests/test_single_country_caf.py
@@ -66,6 +66,7 @@ def test_combined_allele_freq():
     assert all(caf.allele_freq == dirichlet([8, 12, 13]).mean())
 
 
-def test_hdi():
-    hdi = HLAhdi.AFhdi(aftab, credible_interval=0.95)
-    all(hdi.columns == ["lo", "hi", "allele", "post_mean"])
+# Not a meaningful test but slow
+# def test_hdi():
+#     hdi = HLAhdi.AFhdi(aftab, credible_interval=0.95)
+#     assert all(hdi.columns == ["lo", "hi", "allele", "post_mean"])


### PR DESCRIPTION
Tests written for simulated data,
tests that assertion errors are thrown as expected.
Test HLAfreq_pymc non-pymc functions

typos in assertion error messages corrected
AFhdi test removed for speed