### PR TITLE
Relsease 0.0.5

### DIFF
--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
 
     # Get HLA frequency data
     base_url = HLAfreq.makeURL("Uganda", locus="A")
-    aftab = HLAfreq.getAFdata(base_url)
+    aftab = HLAfreq.getAFdata(base_url, timeout=120)
 
     # Preprocess data, checks etc
     aftab = HLAfreq.only_complete(aftab)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="HLAfreq",
-    version="0.0.4",
+    version="0.0.5",
     url="https://github.com/BarinthusBio/HLAfreq",
     project_urls={
         'Documentaion': "https://barinthusbio.github.io/HLAfreq/HLAfreq.html",

--- a/src/HLAfreq/HLAfreq.py
+++ b/src/HLAfreq/HLAfreq.py
@@ -256,7 +256,7 @@ def getAFdata(base_url, timeout=20, format=True, ignoreG=True):
     except requests.exceptions.ReadTimeout as e:
         raise Exception(
             "Requests timeout, try a larger `timeout` value for `getAFdata()`"
-        ) from e
+        ) from None
     # How many pages of results
     N = Npages(bs)
     print("%s pages of results" % N)
@@ -271,7 +271,7 @@ def getAFdata(base_url, timeout=20, format=True, ignoreG=True):
         except requests.exceptions.ReadTimeout as e:
             raise Exception(
                 "Requests timeout, try a larger `timeout` value for `getAFdata()`"
-            ) from e
+            ) from None
         tab = parseAF(bs)
         tabs.append(tab)
     print("Download complete")


### PR DESCRIPTION
- Long `timeout` set in `quickstart.py`
- Simplify getAFdata() error message on timeout